### PR TITLE
fix categoryselector backstack and fullscreen onresume

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
             android:configChanges="orientation|screenSize" />
         <activity
             android:name=".CategorySelectorActivity"
-            android:label="@string/title_activity_category_selector" >
+            android:label="@string/title_activity_category_selector"
+            android:launchMode="singleInstance">
         </activity>
     </application>
 

--- a/app/src/main/java/com/gmail/appytalkteam/appytalkcore/CategorySelectorActivity.java
+++ b/app/src/main/java/com/gmail/appytalkteam/appytalkcore/CategorySelectorActivity.java
@@ -23,6 +23,17 @@ public class CategorySelectorActivity extends AppCompatActivity {
         setContentView(R.layout.activity_category_selector);
 
     }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (Build.VERSION.SDK_INT>=Build.VERSION_CODES.KITKAT) {
+            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+        } else {
+            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE);
+        }
+    }
+
     public void startQuizActivity(View view){
         String category = view.getTag().toString();
         SharedPreferences settings = getSharedPreferences("PrefsFile", MODE_PRIVATE);

--- a/app/src/main/java/com/gmail/appytalkteam/appytalkcore/QuizActivity.java
+++ b/app/src/main/java/com/gmail/appytalkteam/appytalkcore/QuizActivity.java
@@ -82,6 +82,16 @@ public class QuizActivity extends AppCompatActivity implements QuestionFragment.
     }
 
     @Override
+    protected void onResume() {
+        super.onResume();
+        if (Build.VERSION.SDK_INT>=Build.VERSION_CODES.KITKAT) {
+            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+        } else {
+            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE);
+        }
+    }
+
+    @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         keepProgressBarAtTop();

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-include ':app'
+include ':app', ':com.android.support:appcompat-v7', ':com.android.support', ':com.readystatesoftware.sqliteasset', ':com.android.support:percent', ':com.readystatesoftware.sqliteasset:sqliteassethelper', ':com.android.support:support-v4'
 include ':com.android.support:appcompat-v7:22.2.1'
 include ':com.android.support:percent:22.2.0'
 include ':com.android.support:support-v4:22.2.1'


### PR DESCRIPTION
make only one instance of CategorySelector appear when hitting
back button and make sure fullscreen also implemented onresume
