### PR TITLE
set background colour in category selector xml and Quiz activity setup to avoid occasional background glitch in older devices

### DIFF
--- a/app/src/main/java/com/gmail/appytalkteam/appytalkcore/QuizActivity.java
+++ b/app/src/main/java/com/gmail/appytalkteam/appytalkcore/QuizActivity.java
@@ -75,7 +75,7 @@ public class QuizActivity extends AppCompatActivity implements QuestionFragment.
         } else {
             getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE);
         }
-
+        getWindow().getDecorView().setBackgroundColor(getResources().getColor(R.color.backgroundcolor));
         initializeVariables();
         setContentView(R.layout.quiz_activity);
         disableOrientation(); // Because it crashes the sound-loading progress stars

--- a/app/src/main/res/layout/activity_category_selector.xml
+++ b/app/src/main/res/layout/activity_category_selector.xml
@@ -3,7 +3,7 @@
     android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
-
+    android:background="@color/backgroundcolor"
     tools:context="com.gmail.appytalkteam.appytalkcore.CategorySelectorActivity">
     <ImageButton
         android:id="@+id/transparent_background_button"


### PR DESCRIPTION
seems to be working, it was already an intermittent bug, doesn't seem to crop up again so far
